### PR TITLE
re-raise exception if not a request handler

### DIFF
--- a/swirl.py
+++ b/swirl.py
@@ -64,6 +64,8 @@ class CoroutineRunner(object):
                         exc_info=True)
                 else:
                     self.web_handler._handle_request_exception(e)
+            else:
+                raise
 
 def make_asynchronous_decorator(io_loop):
     """


### PR DESCRIPTION
If swirl is used nested, exceptions are swallowed instead of being re-raised inside the outer-most swirl.asynchronous
