### PR TITLE
kwargs in callback_proxy

### DIFF
--- a/swirl.py
+++ b/swirl.py
@@ -32,7 +32,7 @@ class CoroutineRunner(object):
     def execute_work(self):
         return self.work(self.callback_proxy)
 
-    def callback_proxy(self, *args):
+    def callback_proxy(self, *args, **kwargs):
         try:
             if len(args) > 0:
                 if isinstance(args[-1], Exception):


### PR DESCRIPTION
some async callbacks pass keyword arguments. this should be handled in some way. specifically i'm running into this issue using swirl with asyncmongo, which happens to pass back 'error' as a keyword argument.
